### PR TITLE
48 implement test cases for the script GitHub repo_equest_local.py

### DIFF
--- a/src/github_repo_request_local.py
+++ b/src/github_repo_request_local.py
@@ -79,21 +79,33 @@ def parse_args():
 
 def get_base_repo_url(url):
     """
-    Extracts the base repository URL from a GitHub URL.
+    Extracts the base repository URL from a GitHub URL. It handles URLs ending
+     with '.git'.
 
     Args:
-    url (str): The full GitHub URL.
+        url (str): The full GitHub URL.
 
     Returns:
-    str: The base repository URL if valid, otherwise returns None.
+        str: The base repository URL if valid, otherwise returns None.
     """
+    # Return None immediately if the URL is None or empty
+    if not url:
+        return None
+
     parsed_url = urlparse(url)
-    parts = parsed_url.path.strip("/").split("/")
-    if len(parts) >= 2 and not parts[-1].endswith(".git"):
-        # Assumes standard GitHub URLs which are like /owner/repo or /owner/
-        # repo/
+    path = parsed_url.path.strip("/")
+
+    # Check if the path ends with '.git' and strip it off
+    if path.endswith(".git"):
+        path = path[:-4]  # Remove the last 4 characters, '.git'
+
+    parts = path.split("/")
+
+    if len(parts) >= 2:
+        # Format and return the URL with the owner and repository name
         return f"{parsed_url.scheme}://{parsed_url.netloc}/{parts[0]}/{parts[1]}"
-    return None
+    else:
+        return None
 
 
 def list_test_files(directory, excluded_extensions):
@@ -140,178 +152,178 @@ def get_last_commit_hash(repo_dir: Path):
         return None  # Return None to indicate failure
 
 
-args = parse_args()
-# Log the excluded file extensions
-logger.info(f"Excluded file extensions: {', '.join(args.exclude)}")
+if __name__ == "__main__":
+    args = parse_args()
+    # Log the excluded file extensions
+    logger.info(f"Excluded file extensions: {', '.join(args.exclude)}")
 
-# Use get_working_directory_or_git_root to define paths relative to the
-# repository root
-repo_root = get_working_directory_or_git_root()
-updated_csv_path = repo_root / "data" / "updated_local_github_df_test_count.csv"
-clone_dir_base = Path(args.clone_dir)
+    # Use get_working_directory_or_git_root to define paths relative to the
+    # repository root
+    repo_root = get_working_directory_or_git_root()
+    updated_csv_path = repo_root / "data" / "updated_local_github_df_test_count.csv"
+    clone_dir_base = Path(args.clone_dir)
 
-# Ensures the directory exists
-clone_dir_base.mkdir(parents=True, exist_ok=True)
+    # Ensures the directory exists
+    clone_dir_base.mkdir(parents=True, exist_ok=True)
 
-if updated_csv_path.exists():
-    logger.info("Resuming from previously saved progress.")
-    df = pd.read_csv(updated_csv_path)
-else:
-    csv_file_path = repo_root / "data" / "original_github_df.csv"
-
-    if csv_file_path.exists():
-        df = pd.read_csv(csv_file_path)
-        df["testfilecountlocal"] = -1  # Initialise if first run
+    if updated_csv_path.exists():
+        logger.info("Resuming from previously saved progress.")
+        df = pd.read_csv(updated_csv_path)
     else:
-        logger.error(f"CSV file not found at {csv_file_path}.")
+        csv_file_path = repo_root / "data" / "original_github_df.csv"
 
-# Filter out rows where the URL doesn't have a repository name (83 rows)
-if "repourl" in df.columns:
-    # Identify rows with incomplete URLs
-    incomplete_urls = df[
-        df["repourl"].apply(lambda x: len(x.rstrip("/").split("/")) < 5)
-    ]
+        if csv_file_path.exists():
+            df = pd.read_csv(csv_file_path)
+            df["testfilecountlocal"] = -1  # Initialise if first run
+        else:
+            logger.error(f"CSV file not found at {csv_file_path}.")
 
-    # Log the incomplete URLs
-    if not incomplete_urls.empty:
-        logger.info(
-            f"{len(incomplete_urls)} incomplete GitHub URLs found and "
-            f"will be excluded:"
-        )
-        for url in incomplete_urls["repourl"]:
-            logger.info(f"Excluding the repourl : {url}")
+    # Filter out rows where the URL doesn't have a repository name (83 rows)
+    if "repourl" in df.columns:
+        # Identify rows with incomplete URLs
+        incomplete_urls = df[
+            df["repourl"].apply(lambda x: len(x.rstrip("/").split("/")) < 5)
+        ]
 
-    df = df[df["repourl"].apply(lambda x: len(x.rstrip("/").split("/")) >= 5)]
+        # Log the incomplete URLs
+        if not incomplete_urls.empty:
+            logger.info(
+                f"{len(incomplete_urls)} incomplete GitHub URLs found and "
+                f"will be excluded:"
+            )
+            for url in incomplete_urls["repourl"]:
+                logger.info(f"Excluding the repourl : {url}")
 
+        df = df[df["repourl"].apply(lambda x: len(x.rstrip("/").split("/")) >= 5)]
 
-if "last_commit_hash" not in df.columns:
-    df["last_commit_hash"] = None  # Initialize the column with None
+    if "last_commit_hash" not in df.columns:
+        df["last_commit_hash"] = None  # Initialize the column with None
 
-# replace http with https
-df["repourl"] = df["repourl"].str.replace(r"^http\b", "https", regex=True)
+    # replace http with https
+    df["repourl"] = df["repourl"].str.replace(r"^http\b", "https", regex=True)
 
-# Some of the URLs end with "/". I need to remove them.
-df["repourl"] = df["repourl"].str.rstrip("/")
+    # Some of the URLs end with "/". I need to remove them.
+    df["repourl"] = df["repourl"].str.rstrip("/")
 
-# Clean and filter URLs
-df["repourl"] = df["repourl"].apply(get_base_repo_url)
-df = df[df["repourl"].notna()]  # Remove any rows with invalid URLs
+    # Clean and filter URLs
+    df["repourl"] = df["repourl"].apply(get_base_repo_url)
+    df = df[df["repourl"].notna()]  # Remove any rows with invalid URLs
 
-# Number of repositories to process before saving to CSV
-BATCH_SIZE = 10
+    # Number of repositories to process before saving to CSV
+    BATCH_SIZE = 10
 
-# Track the number of processed repositories in the current batch
-processed_count = 0
+    # Track the number of processed repositories in the current batch
+    processed_count = 0
 
-# Define the path for the text file where test file names and URLs will be saved
-test_file_list_path = repo_root / "data" / "test_files_list.txt"
+    # Define the path for the text file where test file names and URLs will be saved
+    test_file_list_path = repo_root / "data" / "test_files_list.txt"
 
-# Open the text file just before the loop begins
-with open(test_file_list_path, "a") as file:
-    for index, row in df.iterrows():
-        # Check if we need to skip this repository because it's fully processed
-        if row["testfilecountlocal"] != -1 and pd.notna(row["last_commit_hash"]):
-            continue
-
-        original_repo_url = row["repourl"]
-        repo_url = get_base_repo_url(original_repo_url)
-        if not repo_url or repo_url is None:
-            logger.info(f"Invalid repository URL: {original_repo_url}")
-            continue
-        repo_name = Path(repo_url.split("/")[-1]).stem
-        clone_dir = clone_dir_base / repo_name
-
-        # Clone only if directory doesn't exist
-        if not clone_dir.exists():
-            try:
-                logger.info(f"Trying to clone {repo_url} into {clone_dir}")
-                subprocess.run(
-                    ["git", "clone", repo_url, str(clone_dir)],
-                    check=True,
-                    capture_output=True,
-                )
-                logger.info(f"Successfully cloned the repo: {repo_name}")
-
-                # Fetch the last commit hash and store it in the DataFrame
-                last_commit_hash = get_last_commit_hash(clone_dir)
-                if last_commit_hash is not None:
-                    df.at[index, "last_commit_hash"] = last_commit_hash
-
-                # On successful clone, increment the processed_count
-                processed_count += 1
-
-            except subprocess.CalledProcessError as e:
-                logger.error(
-                    f"Failed to clone the repo: {repo_name}." f" " f"Exception: {e}"
-                )
-                df.at[index, "testfilecountlocal"] = -1
-
-                # Even on failure, consider it processed for this batch
-                processed_count += 1
-
+    # Open the text file just before the loop begins
+    with open(test_file_list_path, "a") as file:
+        for index, row in df.iterrows():
+            # Check if we need to skip this repository because it's fully processed
+            if row["testfilecountlocal"] != -1 and pd.notna(row["last_commit_hash"]):
                 continue
 
-        # Always attempt to fetch the last commit hash if not already fetched
-        if pd.isna(row["last_commit_hash"]):
-            last_commit_hash = get_last_commit_hash(clone_dir)
-            df.at[index, "last_commit_hash"] = last_commit_hash
+            original_repo_url = row["repourl"]
+            repo_url = get_base_repo_url(original_repo_url)
+            if not repo_url or repo_url is None:
+                logger.info(f"Invalid repository URL: {original_repo_url}")
+                continue
+            repo_name = Path(repo_url.split("/")[-1]).stem
+            clone_dir = clone_dir_base / repo_name
 
-        # Count test files if not already counted
-        if row["testfilecountlocal"] == -1:
-            test_file_names = list_test_files(clone_dir, args.exclude)
-            count = len(test_file_names)
-            df.at[index, "testfilecountlocal"] = count
+            # Clone only if directory doesn't exist
+            if not clone_dir.exists():
+                try:
+                    logger.info(f"Trying to clone {repo_url} into {clone_dir}")
+                    subprocess.run(
+                        ["git", "clone", repo_url, str(clone_dir)],
+                        check=True,
+                        capture_output=True,
+                    )
+                    logger.info(f"Successfully cloned the repo: {repo_name}")
 
-            # Write the repository URL and each test file name to the text file
-            file.write(f"Repository URL: {repo_url}\n")  # Write the repo URL
-            file.writelines(
-                f"{name}\n" for name in test_file_names
-            )  # Write each test file name
-            file.write("\n")  # Add a blank line for separation
-            logger.info(
-                f"Test file names for the repo `{repo_name}`"
-                f" has been written to '{test_file_list_path}'"
-            )
+                    # Fetch the last commit hash and store it in the DataFrame
+                    last_commit_hash = get_last_commit_hash(clone_dir)
+                    if last_commit_hash is not None:
+                        df.at[index, "last_commit_hash"] = last_commit_hash
 
-        processed_count += 1
+                    # On successful clone, increment the processed_count
+                    processed_count += 1
 
-        # Processed count increment and batch check
-        if processed_count >= BATCH_SIZE:
-            # Save the DataFrame to CSV
-            df.to_csv(updated_csv_path, index=False)
-            logger.info(
-                f"Batch of {BATCH_SIZE} repositories processed. "
-                f"Progress saved in {updated_csv_path}."
-            )
+                except subprocess.CalledProcessError as e:
+                    logger.error(
+                        f"Failed to clone the repo: {repo_name}." f" " f"Exception: {e}"
+                    )
+                    df.at[index, "testfilecountlocal"] = -1
 
-            # Reset the processed_count for the next batch
-            processed_count = 0
+                    # Even on failure, consider it processed for this batch
+                    processed_count += 1
 
-# Save any remaining changes at the end of processing
-if processed_count > 0:
-    df.to_csv(updated_csv_path, index=False)
-    logger.info(f"Final batch processed. DataFrame saved in {updated_csv_path}.")
+                    continue
 
-    # Cleanup based on user's command-line option
-    if (
-        not args.keep_clones
-    ):  # If user did not specify --keep-clones, delete the directory
-        shutil.rmtree(clone_dir)
+            # Always attempt to fetch the last commit hash if not already fetched
+            if pd.isna(row["last_commit_hash"]):
+                last_commit_hash = get_last_commit_hash(clone_dir)
+                df.at[index, "last_commit_hash"] = last_commit_hash
 
-logger.info("All repositories processed. DataFrame saved.")
+            # Count test files if not already counted
+            if row["testfilecountlocal"] == -1:
+                test_file_names = list_test_files(clone_dir, args.exclude)
+                count = len(test_file_names)
+                df.at[index, "testfilecountlocal"] = count
 
-# Exporting the result to an RDF format
+                # Write the repository URL and each test file name to the text file
+                file.write(f"Repository URL: {repo_url}\n")  # Write the repo URL
+                file.writelines(
+                    f"{name}\n" for name in test_file_names
+                )  # Write each test file name
+                file.write("\n")  # Add a blank line for separation
+                logger.info(
+                    f"Test file names for the repo `{repo_name}`"
+                    f" has been written to '{test_file_list_path}'"
+                )
 
-# Get the repository root and define the path to save the TTL file
-path_to_save_ttl = repo_root / "data" / "all_data.ttl"
+            processed_count += 1
 
-# Convert DataFrame to Turtle format
-ttl_data = dataframe_to_ttl(df)
+            # Processed count increment and batch check
+            if processed_count >= BATCH_SIZE:
+                # Save the DataFrame to CSV
+                df.to_csv(updated_csv_path, index=False)
+                logger.info(
+                    f"Batch of {BATCH_SIZE} repositories processed. "
+                    f"Progress saved in {updated_csv_path}."
+                )
 
-# Save all Turtle strings to a single file
-with open(path_to_save_ttl, "w") as f:
-    for ttl in ttl_data:
-        f.write(ttl)
-        f.write(
-            "\n"
-        )  # Optionally add a newline between each entry for better readability
+                # Reset the processed_count for the next batch
+                processed_count = 0
+
+    # Save any remaining changes at the end of processing
+    if processed_count > 0:
+        df.to_csv(updated_csv_path, index=False)
+        logger.info(f"Final batch processed. DataFrame saved in {updated_csv_path}.")
+
+        # Cleanup based on user's command-line option
+        if (
+            not args.keep_clones
+        ):  # If user did not specify --keep-clones, delete the directory
+            shutil.rmtree(clone_dir)
+
+    logger.info("All repositories processed. DataFrame saved.")
+
+    # Exporting the result to an RDF format
+
+    # Get the repository root and define the path to save the TTL file
+    path_to_save_ttl = repo_root / "data" / "all_data.ttl"
+
+    # Convert DataFrame to Turtle format
+    ttl_data = dataframe_to_ttl(df)
+
+    # Save all Turtle strings to a single file
+    with open(path_to_save_ttl, "w") as f:
+        for ttl in ttl_data:
+            f.write(ttl)
+            f.write(
+                "\n"
+            )  # Optionally add a newline between each entry for better readability

--- a/src/github_repo_request_local.py
+++ b/src/github_repo_request_local.py
@@ -148,18 +148,19 @@ def get_last_commit_hash(repo_dir: Path):
         return result.stdout.strip()  # Return the commit hash, stripped of any
         # newline characters
     except subprocess.CalledProcessError as e:
-        logger.error(f"Failed to fetch last commit hash for {repo_dir}. Exception: {e}")
+        logger.error(
+            f"Failed to fetch last commit hash for {repo_dir}. " f"Exception: {e}"
+        )
         return None  # Return None to indicate failure
 
 
 def filter_incomplete_urls(df):
     """
     Filters rows in a DataFrame based on the completeness of the 'repourl' URLs.
-    Handles None values by considering them as incomplete URLs.
+    Handles None values and non-string types by considering them as incomplete URLs.
 
     Args:
-        df (pd.DataFrame): DataFrame containing a column named 'repourl' with
-        URLs.
+        df (pd.DataFrame): DataFrame containing a column named 'repourl' with URLs.
 
     Returns:
         pd.DataFrame: DataFrame with rows containing complete URLs.
@@ -174,10 +175,8 @@ def filter_incomplete_urls(df):
 
     # Helper function to determine if a URL is complete
     def is_complete_url(url):
-        if url is None:  # Check for None values directly
-            logger.info(
-                'Found a"repourl" with "None" value. This row will be' "excluded."
-            )
+        # Check if the url is not a string
+        if not isinstance(url, str):
             return False
         parts = url.rstrip("/").split("/")
         return len(parts) >= 5

--- a/src/github_repo_request_local.py
+++ b/src/github_repo_request_local.py
@@ -74,6 +74,18 @@ def parse_args():
         help="Keep cloned repositories after processing. If not specified, "
         "cloned repositories will be deleted.",
     )
+    parser.add_argument(
+        "--input-file",
+        type=str,
+        default=str(Path("data/original_github_df.csv")),
+        help="Path to the input CSV file.",
+    )
+    parser.add_argument(
+        "--output-file",
+        type=str,
+        default=str(Path("data/updated_local_github_df_test_count.csv")),
+        help="Path to the output CSV file.",
+    )
     return parser.parse_args()
 
 
@@ -200,13 +212,17 @@ def filter_incomplete_urls(df):
 
 if __name__ == "__main__":
     args = parse_args()
+    input_file = args.input_file
+    output_file = args.output_file
     # Log the excluded file extensions
     logger.info(f"Excluded file extensions: {', '.join(args.exclude)}")
 
     # Use get_working_directory_or_git_root to define paths relative to the
     # repository root
     repo_root = get_working_directory_or_git_root()
-    updated_csv_path = repo_root / "data" / "updated_local_github_df_test_count.csv"
+    # updated_csv_path = repo_root / "data" / "updated_local_github_df_test_count1.csv"
+    updated_csv_path = repo_root / output_file
+    logger.info(f"updated_csv_path is: {updated_csv_path}")
     clone_dir_base = Path(args.clone_dir)
 
     # Ensures the directory exists
@@ -216,7 +232,7 @@ if __name__ == "__main__":
         logger.info("Resuming from previously saved progress.")
         df = pd.read_csv(updated_csv_path)
     else:
-        csv_file_path = repo_root / "data" / "original_github_df.csv"
+        csv_file_path = repo_root / input_file
 
         if csv_file_path.exists():
             df = pd.read_csv(csv_file_path)

--- a/tests/test_github_repo_request_local.py
+++ b/tests/test_github_repo_request_local.py
@@ -110,4 +110,50 @@ def test_filter_incomplete_urls(data, expected_length, expected_urls):
         "The number of returned rows does not match " "the expected value."
     )
     for url in expected_urls:
-        assert url in result["repourl"].values, f"{url} should be in the result set."
+        assert url in result["repourl"].values, f"{url} should be in the " f"result set"
+
+
+@pytest.mark.parametrize(
+    "data, expected_length",
+    [
+        # Testing different data types
+        (
+            {
+                "repourl": [
+                    None,
+                    "https://github.com/user/repo",
+                    12345,
+                    987.654,
+                    True,
+                    pd.Timestamp("20230101"),
+                ]
+            },
+            1,
+        ),
+        # Test with all entries being non-string types
+        ({"repourl": [12345, 67890, False, pd.Timestamp("20240101"), 987.654]}, 0),
+        # Test with mixed valid URLs and non-string types
+        (
+            {
+                "repourl": [
+                    "https://github.com/user/repo",
+                    "https://github.com/user2/repo2",
+                    12345,
+                    "",
+                ]
+            },
+            2,
+        ),
+    ],
+)
+def test_filter_urls_with_various_data_types(data, expected_length):
+    df = pd.DataFrame(data)
+    result = filter_incomplete_urls(df)
+    assert len(result) == expected_length, (
+        "The number of returned rows does " "not match the expected value."
+    )
+    if expected_length > 0:
+        for url in result["repourl"]:
+            assert isinstance(url, str), (
+                "All returned 'repourl' values should " "be strings."
+            )

--- a/tests/test_github_repo_request_local.py
+++ b/tests/test_github_repo_request_local.py
@@ -1,0 +1,60 @@
+from src.github_repo_request_local import get_base_repo_url
+
+
+def test_get_base_repo_url():
+    # Empty or null input
+    assert get_base_repo_url("") is None
+    assert get_base_repo_url(None) is None
+
+    # Valid URLs
+    assert (
+        get_base_repo_url("https://github.com/getdnsapi/stubby")
+        == "https://github.com/getdnsapi/stubby"
+    )
+
+    assert get_base_repo_url("https://github.com/namecoin") is None
+
+    assert (
+        get_base_repo_url("https://github.com/osresearch/heads/issues/540")
+        == "https://github.com/osresearch/heads"
+    )
+
+    # URLs from other code hosting platforms
+    assert (
+        get_base_repo_url("https://git.sr.ht/~dvn/boxen")
+        == "https://git.sr.ht/~dvn/boxen"
+    )
+
+    assert (
+        get_base_repo_url(
+            "https://redmine.replicant.us/projects/replicant"
+            "/wiki/Tasks_funding#Graphics-acceleration"
+        )
+        == "https://redmine.replicant.us/projects/replicant"
+    )
+
+    # Checking the `repourls` which ends with `.git`
+    assert (
+        get_base_repo_url("https://github.com/stalwartlabs/mail-server.git")
+        == "https://github.com/stalwartlabs/mail-server"
+    )
+
+    assert (
+        get_base_repo_url("https://github.com/tdf/odftoolkit.git")
+        == "https://github.com/tdf/odftoolkit"
+    )
+
+    # Invalid URL formats
+    assert get_base_repo_url("just-a-string") is None
+    assert get_base_repo_url("http:///a-bad-url.com") is None
+
+    # URLs with query parameters or fragments
+    assert (
+        get_base_repo_url("https://github.com/getdnsapi/stubby.git#readme")
+        == "https://github.com/getdnsapi/stubby"
+    )
+
+    assert (
+        get_base_repo_url("https://github.com/getdnsapi/stubby.git?branch=main")
+        == "https://github.com/getdnsapi/stubby"
+    )


### PR DESCRIPTION
- Added test cases for `get_base_repo_url` function in the file `tests/test_github_repo_request_local.py`
- Tests will assert the result of:
  -   Typical GitHub repository URLs with and without '.git' suffix.
  -   URLs pointing to issues and other non-repository pages to test correct base URL extraction.
  -   URLs from other code hosting platforms to ensure versatility.
  -   Edge cases including invalid URLs and URLs with query parameters or fragments.
  -   Empty and None input scenarios to validate function robustness.
  - defined the function `filter_incomplete_urls` in the script `src/github_repo_request_local.py` to be able to write test cases efficiently
- adde a helper function inside the `filter_incomplete_urls` function to handle `None` values of the `repourl`
- changed the function `filter_incomplete_urls` to check if the input url is any type other than string (includes `None`)
- wrote a new parametrised test block (`@pytest.mark.parametrize("data, expected_length"`)  for testing different data types, all entries being non-string types, mixed valid URLs and non-string types
- Added parameterised tests for URL validation with special characters testing for URLs containing unencoded special characters such as single quotes, angle brackets, spaces, and double quotes, to verify that they are correctly identified as invalid.
- I am also working on adding CLI arguments for the input and output data