### PR TITLE
61 including and checking the repo urls for non GitHub repos

### DIFF
--- a/src/github_repo_request_local.py
+++ b/src/github_repo_request_local.py
@@ -23,34 +23,41 @@ of test file records. It saves progress incrementally and can resume where it
 left off, ensuring that data from previous runs is properly managed.
 
 Enhancements include:
+- Organisation of cloned repositories into subdirectories based on the
+'repodomain' column from the input CSV, facilitating better management and
+navigation.
+- Detailed error logging functionality, capturing any issues during the
+repository cloning process and saving these to a separate error log file
+(`data/error_log.txt`).
+- Addition of a 'clone_status' column in the output CSV to record the outcome of
+ each cloning attempt as 'successful' or 'failed'.
+- Improved error handling during cloning operations, including the capture and
+logging of detailed error messages to assist in troubleshooting and ensuring
+robustness.
 
-- Exclusion of specific file extensions during the test file count to tailor
-  the data collection.
+Additional Features:
+- Exclusion of specific file extensions during the test file count to tailor the
+ data collection.
 - Optional retention of cloned repositories post-processing, controlled via
-  command-line arguments.
+command-line arguments.
 - Batch processing capabilities to manage large sets of data efficiently and
-  save progress periodically.
-- Conversion of the final data collection to Turtle (TTL) format for RDF
-  compliant data storage, with the ability to specify the output location.
+save progress periodically.
+- Conversion of the final data collection to Turtle (TTL) format for
+RDF-compliant data storage, with the ability to specify the output location.
 - Writing of repository URLs and associated test filenames to a text file for
-  easy auditing and verification. The location of this text file can be
-  specified via command-line arguments.
-
-Users can specify excluded file extensions, choose a custom directory for
-cloning repositories, and set paths for output files (both CSV and text formats).
-The script also allows specification of the output path for the TTL format file,
-facilitating easy integration with semantic web technologies.
+easy auditing and verification. The location of this text file can be specified
+ via command-line arguments.
 
 Command Line Arguments:
 - --exclude: Specify file extensions to exclude from test file counts.
 - --clone-dir: Set a custom directory for cloning the repositories.
 - --keep-clones: Option to retain cloned repositories after processing, which
-  can be useful for subsequent manual reviews or further automated tasks.
+can be useful for subsequent manual reviews or further automated tasks.
 - --input-file: Path to the input CSV file.
 - --output-file: Path to the output CSV file that includes test file counts and
-  last commit hashes.
-- --test-file-list: Path to the text file for recording repository URLs and
-  test filenames.
+last commit hashes.
+- --test-file-list: Path to the text file for recording repository URLs and test
+  filenames.
 - --ttl-file: Path to save the Turtle (TTL) format file.
 """
 

--- a/src/github_repo_request_local.py
+++ b/src/github_repo_request_local.py
@@ -1,13 +1,15 @@
-import re
 import argparse
+import re
+import shutil
 import subprocess
+import sys
 from pathlib import Path
+
 import pandas as pd
 from loguru import logger
+
 from utils.git_utils import get_working_directory_or_git_root
 from utils.export_to_rdf import dataframe_to_ttl
-import shutil
-import sys
 
 """
 This script automates the process of cloning GitHub repositories listed in a
@@ -177,6 +179,7 @@ if __name__ == "__main__":
     args = parse_args()
     input_file = args.input_file
     output_file = args.output_file
+
     # Log the excluded file extensions
     logger.info(f"Excluded file extensions: {', '.join(args.exclude)}")
 
@@ -213,7 +216,7 @@ if __name__ == "__main__":
             sys.exit(1)
 
     if "last_commit_hash" not in df.columns:
-        df["last_commit_hash"] = None  # Initialize the column with None
+        df["last_commit_hash"] = None  # Initialise the column with None
 
     # Number of repositories to process before saving to CSV
     BATCH_SIZE = 10
@@ -241,9 +244,11 @@ if __name__ == "__main__":
                 continue
 
             repo_domain = row["repodomain"]
+
             # Sanitise the domain name
             sanitised_domain = sanitise_directory_name(repo_domain)
             repo_name = Path(repo_url.split("/")[-1]).stem
+
             # Adjusted path including domain
             domain_specific_dir = clone_dir_base / sanitised_domain
             domain_specific_dir.mkdir(parents=True, exist_ok=True)
@@ -276,7 +281,7 @@ if __name__ == "__main__":
                     error_message = e.stderr.strip()
                     logger.error(
                         f"Failed to clone the repo: {repo_name}.Exception: {e},"
-                        f"Error mesage {error_message}"
+                        f"Error message {error_message}"
                     )
                     df.at[index, "clone_status"] = "failed"
                     df.at[index, "testfilecountlocal"] = -1
@@ -290,8 +295,7 @@ if __name__ == "__main__":
                     )
                     continue
             else:
-                # If already exists, consider as successful unless checked
-                # otherwise
+                # If cloned directory already exists, consider as successful
                 df.at[index, "clone_status"] = "successful"
 
             # Always attempt to fetch the last commit hash if not already

--- a/src/github_repo_request_local.py
+++ b/src/github_repo_request_local.py
@@ -1,5 +1,4 @@
 import argparse
-import re
 import shutil
 import subprocess
 import sys
@@ -10,6 +9,7 @@ from loguru import logger
 
 from utils.git_utils import get_working_directory_or_git_root
 from utils.export_to_rdf import dataframe_to_ttl
+from utils.string_utils import sanitise_directory_name
 
 """
 This script automates the process of cloning GitHub repositories listed in a
@@ -163,16 +163,6 @@ def get_last_commit_hash(repo_dir: Path):
             f"Failed to fetch last commit hash for {repo_dir}. " f"Exception: {e}"
         )
         return None  # Return None to indicate failure
-
-
-def sanitise_directory_name(name):
-    """Sanitise the directory name by removing or replacing non-alphanumeric
-    characters."""
-    # Replace periods and other non-alphanumeric characters with an underscore
-    # This regex replaces all non-alphanumeric, non-hyphen characters with an
-    # underscore
-    sanitised_name = re.sub(r"[^\w-]", "_", name)
-    return sanitised_name
 
 
 if __name__ == "__main__":

--- a/tests/test_github_repo_request_local.py
+++ b/tests/test_github_repo_request_local.py
@@ -35,6 +35,24 @@ def test_get_base_repo_url():
         == "https://redmine.replicant.us/projects/replicant"
     )
 
+    # Test for Codeberg and Framagit profiles and repositories
+    assert get_base_repo_url("https://codeberg.org/interpeer") is None
+    assert (
+        get_base_repo_url("https://codeberg.org/forgejo/forgejo")
+        == "https://codeberg.org/forgejo/forgejo"
+    )
+    assert get_base_repo_url("https://framagit.org/incommon.cc") is None
+    assert (
+        get_base_repo_url("https://framagit.org/framasoft/CHAP/mobilizon")
+        == "https://framagit.org/framasoft/CHAP/mobilizon"
+    )
+
+    # Test for GitLab with nested groups
+    assert (
+        get_base_repo_url("https://gitlab.com/technostructures/kazarma/kazarma")
+        == "https://gitlab.com/technostructures/kazarma/kazarma"
+    )
+
     # Checking the `repourls` which ends with `.git`
     assert (
         get_base_repo_url("https://github.com/stalwartlabs/mail-server.git")
@@ -45,6 +63,17 @@ def test_get_base_repo_url():
         get_base_repo_url("https://github.com/tdf/odftoolkit.git")
         == "https://github.com/tdf/odftoolkit"
     )
+
+    # Test URLs from hosts that require '.git' in the path
+    assert (
+        get_base_repo_url("https://git.savannah.gnu.org/git/mes.git")
+        == "https://git.savannah.gnu.org/git/mes.git"
+    )
+    assert (
+        get_base_repo_url("https://git.taler.net/git/libtalerutil.git")
+        == "https://git.taler.net/git/libtalerutil.git"
+    )
+    assert get_base_repo_url("https://git.taler.net/taler-ios.git") is None
 
     # Invalid URL formats
     assert get_base_repo_url("just-a-string") is None

--- a/tests/test_github_repo_request_local.py
+++ b/tests/test_github_repo_request_local.py
@@ -13,9 +13,7 @@ def test_get_base_repo_url():
         get_base_repo_url("https://github.com/getdnsapi/stubby")
         == "https://github.com/getdnsapi/stubby"
     )
-
     assert get_base_repo_url("https://github.com/namecoin") is None
-
     assert (
         get_base_repo_url("https://github.com/osresearch/heads/issues/540")
         == "https://github.com/osresearch/heads"
@@ -26,7 +24,6 @@ def test_get_base_repo_url():
         get_base_repo_url("https://git.sr.ht/~dvn/boxen")
         == "https://git.sr.ht/~dvn/boxen"
     )
-
     assert (
         get_base_repo_url(
             "https://redmine.replicant.us/projects/replicant"
@@ -35,36 +32,11 @@ def test_get_base_repo_url():
         == "https://redmine.replicant.us/projects/replicant"
     )
 
-    # Test for Codeberg and Framagit profiles and repositories
-    assert get_base_repo_url("https://codeberg.org/interpeer") is None
-    assert (
-        get_base_repo_url("https://codeberg.org/forgejo/forgejo")
-        == "https://codeberg.org/forgejo/forgejo"
-    )
-    assert get_base_repo_url("https://framagit.org/incommon.cc") is None
-    assert (
-        get_base_repo_url("https://framagit.org/framasoft/CHAP/mobilizon")
-        == "https://framagit.org/framasoft/CHAP/mobilizon"
-    )
-
-    # Test for GitLab with nested groups
-    assert (
-        get_base_repo_url("https://gitlab.com/technostructures/kazarma/kazarma")
-        == "https://gitlab.com/technostructures/kazarma/kazarma"
-    )
-
     # Checking the `repourls` which ends with `.git`
     assert (
-        get_base_repo_url("https://github.com/stalwartlabs/mail-server.git")
-        == "https://github.com/stalwartlabs/mail-server"
-    )
-
-    assert (
         get_base_repo_url("https://github.com/tdf/odftoolkit.git")
-        == "https://github.com/tdf/odftoolkit"
+        == "https://github.com/tdf/odftoolkit.git"
     )
-
-    # Test URLs from hosts that require '.git' in the path
     assert (
         get_base_repo_url("https://git.savannah.gnu.org/git/mes.git")
         == "https://git.savannah.gnu.org/git/mes.git"
@@ -73,8 +45,10 @@ def test_get_base_repo_url():
         get_base_repo_url("https://git.taler.net/git/libtalerutil.git")
         == "https://git.taler.net/git/libtalerutil.git"
     )
-    assert get_base_repo_url("https://git.taler.net/taler-ios.git") is None
-
+    assert (
+        get_base_repo_url("https://git.taler.net/taler-ios.git")
+        == "https://git.taler.net/taler-ios.git"
+    )
     # Invalid URL formats
     assert get_base_repo_url("just-a-string") is None
     assert get_base_repo_url("http:///a-bad-url.com") is None
@@ -82,12 +56,72 @@ def test_get_base_repo_url():
     # URLs with query parameters or fragments
     assert (
         get_base_repo_url("https://github.com/getdnsapi/stubby.git#readme")
-        == "https://github.com/getdnsapi/stubby"
+        == "https://github.com/getdnsapi/stubby.git"
     )
 
     assert (
         get_base_repo_url("https://github.com/getdnsapi/stubby.git?branch=main")
-        == "https://github.com/getdnsapi/stubby"
+        == "https://github.com/getdnsapi/stubby.git"
+    )
+    # Writing test for direct_path_platforms
+    #         "gitlab.com",
+    #         "gitlab.torproject.org",
+    #         "codeberg.org",
+    #         "framagit.org",
+    #         "hydrillabugs.koszko.org",
+    #         "git.replicant.us",
+    #         "gerrit.osmocom.org",
+    #         "git.taler.net"
+
+    assert (
+        get_base_repo_url("https://gitlab.com/technostructures/kazarma/kazarma")
+        == "https://gitlab.com/technostructures/kazarma/kazarma"
+    )
+
+    assert (
+        get_base_repo_url("https://gitlab.torproject.org/tpo/network-heal")
+        == "https://gitlab.torproject.org/tpo/network-heal"
+    )
+
+    assert (
+        get_base_repo_url("https://codeberg.org/interpeer")
+        == "https://codeberg.org/interpeer"
+    )
+
+    assert (
+        get_base_repo_url("https://codeberg.org/openEngiadina/geopub")
+        == "https://codeberg.org/openEngiadina/geopub"
+    )
+
+    assert (
+        get_base_repo_url("https://codeberg.org/librEDA")
+        == "https://codeberg.org/librEDA"
+    )
+
+    assert (
+        get_base_repo_url("https://framagit.org/incommon.cc")
+        == "https://framagit.org/incommon.cc"
+    )
+
+    assert (
+        get_base_repo_url(
+            "https://hydrillabugs.koszko.org/projects/haketilo/repository"
+        )
+        == "https://hydrillabugs.koszko.org/projects/haketilo/repository"
+    )
+
+    assert (
+        get_base_repo_url("https://git.replicant.us/replicant")
+        == "https://git.replicant.us/replicant"
+    )
+
+    assert (
+        get_base_repo_url("https://gerrit.osmocom.org/plugins/gitiles/ims")
+        == "https://gerrit.osmocom.org/plugins/gitiles/ims"
+    )
+
+    assert get_base_repo_url("https://git.taler.net/taler-ios.git") == (
+        "https://git.taler.net/taler-ios.git"
     )
 
 

--- a/tests/test_string_utils.py
+++ b/tests/test_string_utils.py
@@ -1,0 +1,28 @@
+import pytest
+from utils.string_utils import sanitise_directory_name
+
+
+@pytest.mark.parametrize(
+    "input_str, expected",
+    [
+        ("example_directory", "example_directory"),
+        ("example directory", "example_directory"),
+        ("example_directory@2024!", "example_directory_2024_"),
+        ("example.directory.com", "example_directory_com"),
+        ("", ""),
+        ("@#$%^&*()!", "__________"),
+        ("123@#$", "123___"),
+        ("well-named-directory", "well-named-directory"),
+        ("!directory-name!", "_directory-name_"),
+    ],
+)
+def test_sanitise_directory_name(input_str, expected):
+    assert (
+        sanitise_directory_name(input_str) == expected
+    ), f"Failed for input: {input_str}"
+
+
+# To handle non-string inputs and ensure the function raises an error:
+def test_sanitise_non_string_input():
+    with pytest.raises(TypeError):
+        sanitise_directory_name(123)

--- a/utils/initial_data_preparation.py
+++ b/utils/initial_data_preparation.py
@@ -1,31 +1,24 @@
 """
-This script processes a TSV file to create a DataFrame, from which it extracts
-domains and organises entries into separate DataFrames based on these domains.
-Each domain-specific DataFrame is saved as a CSV file if it contains more than
-10 records. Additionally, the script performs data cleaning by removing rows
-with null values and duplicates, and ensures URLs are complete and well-formed
-before extracting the domain for analysis.
-
-The script also includes functionality to replace HTTP with HTTPS in URLs,
-remove trailing slashes, and save the count of repositories for each domain
-into a text file, facilitating easy reference and further analysis. It's
-designed for flexibility, supporting command-line arguments that allow users to
-specify custom paths for the input TSV file and the output directory.
+This script processes a TSV file to create a DataFrame, performs data
+cleaning, and organises entries into separate DataFrames based on the domain
+extracted from URLs. Each domain-specific DataFrame is saved as a CSV file if
+it contains more than 10 records. It also performs detailed data cleaning by
+removing rows with null values and duplicates, and ensures URLs are complete
+and well-formed before extracting the domain for analysis.
 
 Features:
-- Reads a TSV file specified by the user.
-- Performs data cleaning, including checking for null values,
-  duplicates, and URL completeness.
-- Extracts the domain from each URL in the 'repourl' column to determine where
-  the code is hosted.
-- Separates the DataFrame into multiple DataFrames based on unique domains,
-  facilitating domain-specific analyses.
-- Saves DataFrames with more than 10 entries to a structured directory format,
-  catering to repositories hosted under distinct domains.
-- Outputs the count of repositories for each domain into a text file for easy
-  reference and further analysis.
-- Converts HTTP to HTTPS in URLs and cleans them by removing trailing slashes.
-
+- **Data Input and Cleaning**: Reads a user-specified TSV file to create a
+DataFrame, checks for null values and duplicates, and ensures that URLs are
+complete and well-formed. The script also converts HTTP URLs to HTTPS and
+removes trailing slashes to standardise URL formats.
+- **Domain Extraction and Organisation**: Extracts domains from URLs and
+organises the data into separate DataFrames based on these domains.
+- **Data Output**: Saves DataFrames that contain more than 10 entries as CSV
+in a structured directory format, catering to repositories hosted under distinct
+domains. Additionally, it outputs the count of repositories for each domain
+into a text file for easy reference and further analysis.
+- **Command Line Flexibility**: Supports command-line arguments that allow users
+to specify custom paths for the input TSV file and the output directory.
 Command Line Arguments:
 - --input-file: Specifies the path to the input TSV file.
 - --output-folder: Specifies the directory where output CSV files and other

--- a/utils/initial_data_preparation.py
+++ b/utils/initial_data_preparation.py
@@ -39,6 +39,7 @@ import argparse
 from pathlib import Path
 from loguru import logger
 from utils.git_utils import get_working_directory_or_git_root
+from utils.string_utils import sanitise_directory_name
 import os
 from urllib.parse import urlparse
 
@@ -200,19 +201,6 @@ def get_base_repo_url(url):
     parsed_url = urlparse(url)
     path = parsed_url.path.strip("/")
 
-    # Host-specific criteria for handling '.git'
-    hosts_with_mandatory_git_suffix = [
-        "git.savannah.gnu.org",
-        "git.torproject.org",
-        "git.taler.net",
-    ]
-    should_strip_git = not any(
-        host in parsed_url.netloc for host in hosts_with_mandatory_git_suffix
-    )
-
-    if path.endswith(".git") and should_strip_git:
-        path = path[:-4]  # Remove the last 4 characters, '.git'
-
     parts = path.split("/")
     print(f"parts: {parts}")
 
@@ -319,7 +307,7 @@ if __name__ == "__main__":
     # Save the dataframe as a CSV file
     df.to_csv(output_dir / "original_massive_df.csv", index=False)
     logger.info(
-        f'Dataframe "original_massive_df" is created from the '
+        f'Dataframe "original_massive_df.csv" has been created from the '
         f'"original_df.csv" '
         f"file and saved in {output_dir} "
     )
@@ -372,7 +360,7 @@ if __name__ == "__main__":
     for domain, domain_df in dfs_by_domain.items():
         if len(domain_df) >= 10:
             domain_df.to_csv(
-                data_folder / f"{domain.replace('/', '_').replace(':', '_')}.csv",
+                data_folder / f"{sanitise_directory_name(domain)}.csv",
                 index=False,
             )
             logger.info(

--- a/utils/initial_data_preparation.py
+++ b/utils/initial_data_preparation.py
@@ -295,7 +295,7 @@ if __name__ == "__main__":
     # Removing duplicate rows
     remove_duplicates(df)
 
-    # Removing null value is any (There is no null values in the data at the
+    # Removing null value if any (There is no null values in the data at this
     # moment)
     remove_null_values(df)
 

--- a/utils/string_utils.py
+++ b/utils/string_utils.py
@@ -1,0 +1,11 @@
+import re
+
+
+def sanitise_directory_name(name):
+    """Sanitise the directory name by removing or replacing non-alphanumeric
+    characters."""
+    # Replace periods and other non-alphanumeric characters with an underscore
+    # This regex replaces all non-alphanumeric, non-hyphen characters with an
+    # underscore
+    sanitised_name = re.sub(r"[^\w-]", "_", name)
+    return sanitised_name


### PR DESCRIPTION
Hi Julian,

Could you please review the changes in this PR and let me know if anything needs to be changed?

Key changes are:
Script `src/github_repo_request_local.py`:
- Directory Structure by Domain: Modified the cloning path to create subdirectories based on the 'repodomain' column from the input DataFrame.
- Enhanced Error Handling: Implemented capturing of detailed error messages during the repository cloning process.
- Added functionality to write these error messages, along with the repository URL, to a dedicated error log file (data/error_log.txt).
- DataFrame Updates: Introduced a 'clone_status' column to track the success or failure of each cloning attempt, enhancing the script's reporting capabilities.

Script `utils/initial_data_preparation.py`:
- updated the `get_base_repo_url`  function to better handle a variety of Git hosting platforms.

Script `tests/test_github_repo_request_local.py`:
- Expand test coverage for get_base_repo_url with multi-platform scenarios

Thanks